### PR TITLE
Fix wiki scrapers for updated HTML structure

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -20,13 +20,17 @@ class DB {
     url += IP
     url += '/' + dbName
 
-    mongoose.connect(url, { useNewUrlParser: true })
+    this.connectionPromise = mongoose.connect(url, { useNewUrlParser: true })
       .then(() => { console.log('Successfully connected to database') })
-      .catch((error) => { console.log(error) })
+      .catch((error) => { console.log(error); throw error })
   }
 
   getConnection () {
     return mongoose.connection
+  }
+
+  async waitForConnection () {
+    return this.connectionPromise
   }
 }
 
@@ -44,6 +48,10 @@ class DBI {
 
   static initConnection () {
     this.getInterface()
+  }
+
+  static async waitForConnection () {
+    return this.getInterface().waitForConnection()
   }
 }
 

--- a/jobs/char_jobs.js
+++ b/jobs/char_jobs.js
@@ -7,8 +7,8 @@ class charJobs {
 
   // Characters
   static #charactersURL = 'https://deadbydaylight.fandom.com/wiki/Characters'
-  static #survivorsSelector = "h2:has(span[id^='Survivors'])+dl+div"
-  static #killersSelector = "h2:has(span[id^='Killers'])+dl+div"
+  static #survivorsSelector = "h2:has(span[id='Survivors'])+dl+div"
+  static #killersSelector = "h2:has(span[id='Killers'])+dl+div"
 
   static #retrieveCharacters (selector) {
     if (!selector) { return false }
@@ -27,26 +27,35 @@ class charJobs {
           return
         }
 
-        CharTable.childNodes.forEach(charDiv => {
+        // Filter to only element nodes (skip text nodes)
+        const charDivs = CharTable.childNodes.filter(node => node.nodeType === 1)
+
+        charDivs.forEach(charDiv => {
           if (!charDiv.childNodes?.length >= 2) { return }
 
-          // Character Info
-          const charA = charDiv.querySelectorAll('a')[0]
+          // Character Info - first <a> tag has the character name
+          const charA = charDiv.querySelector('a')
+          if (!charA) { return }
 
-          const characterName = charA.innerText
+          const characterName = charA.innerText?.trim()
+          if (!characterName) { return }
+
           let killerName
 
           if (isKiller) {
-            killerName = charDiv.innerText.split(' - ').pop()
+            // Killer name appears as text after the character name link
+            // e.g., "Evan MacMillan" link followed by "The Trapper" text
+            const fullText = charDiv.innerText?.trim() || ''
+            // The killer name is everything after the character name
+            killerName = fullText.replace(characterName, '').trim()
           }
 
-          const URIName = charA.attributes.href.split('/').pop() // Should only be 3% slower than arr[arr.length - 1]
+          const URIName = charA.attributes.href?.split('/').pop()
           const characterLink = this.#addURL + charA.attributes.href
 
-          // Character Image
-          const imgA = charDiv.querySelectorAll('img')[0]
-
-          const characterImage = imgA.attributes['data-src']
+          // Character Image - find img with data-src attribute
+          const img = charDiv.querySelector('img[data-src]')
+          const characterImage = img?.attributes['data-src']
 
           const characterData = { name: characterName, killerName, URIName, iconURL: characterImage, link: characterLink }
 
@@ -77,7 +86,7 @@ class charJobs {
 
       console.log('Successfully fetched Survivors.')
     } catch (error) {
-      throw new Error('Failed fetching Survivors')
+      throw new Error('Failed fetching Survivors: ' + error.message)
     }
   }
 
@@ -100,7 +109,7 @@ class charJobs {
 
       console.log('Successfully fetched Killers.')
     } catch (error) {
-      throw new Error('Failed fetching Killers')
+      throw new Error('Failed fetching Killers: ' + error.message)
     }
   }
 

--- a/update.js
+++ b/update.js
@@ -2,31 +2,26 @@ import perkJobs from './jobs/perk_jobs.js'
 import charJobs from './jobs/char_jobs.js'
 import DBI from './db/db.js'
 
-// Open connection if not already connected
+// Open connection and wait for it to be ready
 DBI.initConnection()
 
-// Keep this for later, as we're going to add more scraping to our DB
-let perksUpdated; let charactersUpdated = false
+async function runUpdate () {
+  // Wait for database connection to be ready
+  await DBI.waitForConnection()
 
-function closeProcess () {
-  if (perksUpdated && charactersUpdated) {
-    console.log('Database update finished.')
-    process.exit(0)
-  }
+  // Update characters first
+  const charRes = await charJobs.updateKillersAndSurvivors()
+  console.log(charRes)
+
+  // Then update perks
+  const perkRes = await perkJobs.updateKillerAndSurvivorPerks()
+  console.log(perkRes)
+
+  console.log('Database update finished.')
+  process.exit(0)
 }
 
-// Update perks after app is built & every hour, instead of every time the dyno starts
-
-// Update characters first
-charJobs.updateKillersAndSurvivors().then(res => {
-  console.log(res)
-  charactersUpdated = true
-
-  // Then upgrade perks
-  perkJobs.updateKillerAndSurvivorPerks().then(res => {
-    console.log(res)
-    perksUpdated = true
-    closeProcess()
-  })
+runUpdate().catch(err => {
+  console.error('Update failed:', err)
+  process.exit(1)
 })
-// Close process to stop it from launching server.


### PR DESCRIPTION
## Summary
- Update CSS selectors for changed wiki page structure
- Filter text nodes when iterating child elements
- Fix killer name extraction (no longer uses " - " separator)
- Remove dependency on `.formattedPerkDesc` class (no longer exists)
- Add `waitForConnection()` to ensure DB is ready before operations
- Rewrite update.js to use async/await pattern
- Improve error messages to include actual error details

## Test plan
- [x] Verified `npm run heroku-cleanup` successfully scrapes all killers (41), survivors (48), killer perks (133), and survivor perks (149)
- [x] Verified API endpoints return correct data